### PR TITLE
fix badges plugin so now it properly works

### DIFF
--- a/Badges.plugin.js
+++ b/Badges.plugin.js
@@ -2,7 +2,7 @@
  * @name Badges
  * @author John Fries
  * @authorId 630070645874622494
- * @version 1.0.1
+ * @version 1.0.2
  * @description Simple plugin that gives you all badges
  * @website https://johnfries.net/bot
  * @updateUrl https://github.com/John-Fries-J/Badges-plugin/blob/068ee722c9e1416afdde0fc119a5156e9d6d5a21/Badges.plugin.js
@@ -10,8 +10,14 @@
  * @invite pqXYh3PQtk
  */
 
- module.exports = class Badges {
+const settingsStore = BdApi.findModule(m => typeof m?.default?.isDeveloper !== "undefined");
+const userStore = BdApi.findModule(m => m?.default?.getUsers); 
 
+module.exports = class {
+
+    getName() {
+        return "Discord Badges";
+    }
 
     start = () => {
         (() => {


### PR DESCRIPTION
For some reason, the plugin did not properly load. With this required changes, all badges now work. 